### PR TITLE
mirror: don't pass error from timeConnect

### DIFF
--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -10,7 +10,10 @@ function timeConnection(item,callback){
       '/json.php?ids=1&fields=*'
   };
   request(httpOptions, function(err,response,body){
-    if (err) return callback(err);
+    // async.map will fail if any of the timeConnections returns an
+    // error; so fail silently
+    if (err) return callback(null);
+
     if (response.statusCode !== 200){
       return callback(null,false);
     }


### PR DESCRIPTION
async.map should only fail if none of the mirrors succeed